### PR TITLE
feat: Add export as HTML functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
                 <button id="new-file-btn">New File</button>
                 <button id="save-dvk-btn">Save (.dvk)</button>
                 <button id="load-dvk-btn">Load (.dvk)</button>
+                <button id="export-html-btn">Export (.html)</button>
                 <input type="file" id="load-dvk-input" accept=".dvk" style="display: none;">
             </div>
             <!-- Quill Toolbar will be moved here by JavaScript -->

--- a/script.js
+++ b/script.js
@@ -67,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const saveDvkBtn = document.getElementById('save-dvk-btn');
     const loadDvkBtn = document.getElementById('load-dvk-btn');
     const loadDvkInput = document.getElementById('load-dvk-input');
+    const exportHtmlBtn = document.getElementById('export-html-btn');
 
     // New File
     if (newFileBtn) {
@@ -76,6 +77,26 @@ document.addEventListener('DOMContentLoaded', () => {
                 console.log("New file created (editor cleared).");
             } else {
                 console.error("Quill editor not found for new file operation.");
+            }
+        });
+    }
+
+    // Export (.html)
+    if (exportHtmlBtn) {
+        exportHtmlBtn.addEventListener('click', () => {
+            if (window.quill) {
+                const content = window.quill.root.innerHTML; // Get HTML content
+                const blob = new Blob([content], { type: 'text/html' });
+                const a = document.createElement('a');
+                a.href = URL.createObjectURL(blob);
+                a.download = 'document.html'; // Default filename
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(a.href); // Clean up
+                console.log("Document exported as document.html");
+            } else {
+                console.error("Quill editor not found for export operation.");
             }
         });
     }


### PR DESCRIPTION
Adds an 'Export (.html)' button to the editor controls. When clicked, the button triggers a download of the current editor content as an HTML file named 'document.html'.

Includes changes to:
- index.html: Added the new button.
- script.js: Added JavaScript logic to handle the button click and file download.